### PR TITLE
Sign Up: Service Provider Onboarding (3 of N)

### DIFF
--- a/src/app/api/v1/customers/sign-up/route.ts
+++ b/src/app/api/v1/customers/sign-up/route.ts
@@ -8,7 +8,7 @@ import { customerSignupFormSchema } from '@/types/forms'
 import { stripe } from '@/server/services/stripe'
 import { logger } from '@/server/lib/logger'
 
-type SignupResponse =
+export type SignupResponse =
   | {
       success: true
       message?: string

--- a/src/app/api/v1/service-providers/sign-up/route.ts
+++ b/src/app/api/v1/service-providers/sign-up/route.ts
@@ -1,0 +1,235 @@
+import { NextResponse } from 'next/server'
+import { AuthError, PostgrestError } from '@supabase/supabase-js'
+import to from 'await-to-js'
+import Stripe from 'stripe'
+import { ZodError } from 'zod'
+
+import { SignupResponse } from '../../customers/sign-up/route'
+import { createClient } from '@/utils/supabase/server'
+import { serviceProviderSignupFormSchema } from '@/types/forms'
+import { logger } from '@/server/lib/logger'
+import { stripe } from '@/server/services/stripe'
+
+/**
+ * This function handles error and success responses for the Service Provider sign-up route.
+ * See the handleServiceProviderSignup function for the main logic.
+ */
+export const POST = async (
+  req: Request,
+): Promise<NextResponse<SignupResponse>> => {
+  const { error } = await handleServiceProviderSignup(req)
+
+  if (error instanceof ZodError) {
+    logger.error({ error }, 'Service Providers Signup: Input Validation Error')
+    return NextResponse.json(
+      { success: false, message: error.message, error },
+      { status: 400 },
+    )
+  }
+
+  if (error instanceof AuthError) {
+    logger.error({ error }, 'Service Providers Signup: Supabase Auth Error')
+    return NextResponse.json(
+      {
+        success: false,
+        message: error.message,
+        error,
+      },
+      { status: error.status },
+    )
+  }
+
+  if (error) {
+    logger.error({ error }, 'Service Providers Signup: Error')
+    return NextResponse.json(
+      { success: false, message: error.message, error },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}
+
+/**
+ * Handles the signup form for our Service Provider users.
+ */
+async function handleServiceProviderSignup(
+  req: Request,
+): Promise<
+  | { success: false; error: Error | PostgrestError }
+  | { success: true; error: null }
+> {
+  // validation
+  const supabase = createClient()
+
+  const validationResult = serviceProviderSignupFormSchema.safeParse(
+    await req.formData(),
+  )
+
+  if (validationResult.success === false) {
+    return { success: false, error: validationResult.error }
+  }
+
+  const {
+    email,
+    password,
+    company_name: companyName,
+    abn,
+    acn,
+    industry,
+    preferred_name: preferredName,
+    fullname,
+  } = validationResult.data
+
+  // sign up new user
+  const metadata = {
+    role: 'service-provider',
+    onboarded: false,
+    preferred_name: preferredName,
+    fullname,
+    service_providers: {
+      stripe_account_id: null,
+      onboarding_url: null,
+    },
+    companyDetails: {
+      companyName,
+      abn,
+      acn,
+      industry,
+    },
+  }
+
+  const signupResult = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: metadata,
+    },
+  })
+
+  if (signupResult.error) {
+    return { success: false, error: signupResult.error }
+  }
+
+  const userId = signupResult.data?.user?.id as string
+
+  // new service provider
+  const insertServiceProviderResult = await supabase
+    .from('service_providers')
+    .insert([
+      {
+        user_id: userId,
+        company_name: companyName,
+        abn,
+        acn,
+        industry,
+        preferred_name: preferredName,
+        fullname,
+        slug: slugify(companyName),
+      },
+    ])
+
+  if (insertServiceProviderResult.error) {
+    return {
+      success: false,
+      error: insertServiceProviderResult.error,
+    }
+  }
+
+  // create new stripe account
+  const [stripeAccountError, stripeAccount] = await to(
+    createStripeConnectAccount({
+      userId,
+      email,
+    }),
+  )
+
+  if (stripeAccountError) {
+    return { success: false, error: stripeAccountError }
+  }
+
+  const serviceProviderId = stripeAccount.id
+
+  // get onboarding url
+  const [stripeRedirectError, stripeRedirect] = await to(
+    createStripeConnectRedirectLink(serviceProviderId),
+  )
+
+  if (stripeRedirectError) {
+    return { success: false, error: stripeRedirectError }
+  }
+
+  // save to metadata
+  const updatedMetadata = {
+    role: 'service-provider',
+    onboarded: false,
+    preferred_name: preferredName,
+    fullname,
+    service_providers: {
+      stripe_account_id: serviceProviderId,
+      onboarding_url: stripeRedirect.url,
+    },
+  }
+
+  const updateAuthUserResult = await supabase.auth.updateUser({
+    data: updatedMetadata,
+  })
+
+  if (updateAuthUserResult.error) {
+    return { success: false, error: updateAuthUserResult.error }
+  }
+
+  return { success: true, error: null }
+}
+
+export type CreateStripeConnectAccountParams = {
+  userId: string
+  email: string
+  companyType?: 'sole_proprietorship'
+}
+
+export async function createStripeConnectAccount(
+  params: CreateStripeConnectAccountParams,
+) {
+  const accountParams: Stripe.AccountCreateParams = {
+    type: 'express',
+    business_type: 'company',
+    capabilities: {
+      card_payments: { requested: true },
+      transfers: { requested: true },
+    },
+    company: {
+      structure: params?.companyType ?? 'sole_proprietorship',
+    },
+    email: params.email,
+
+    metadata: { userId: params.userId },
+  }
+
+  return await stripe.accounts.create(accountParams)
+}
+
+export async function createStripeConnectRedirectLink(accountId: string) {
+  if (!process.env.STRIPE_RETURN_URL || !process.env.STRIPE_REFRESH_URL)
+    throw new Error('STRIPE_RETURN_URL or STRIPE_REFRESH_URL not set')
+
+  return await stripe.accountLinks.create({
+    account: accountId,
+    return_url: process.env.STRIPE_RETURN_URL,
+    refresh_url: process.env.STRIPE_REFRESH_URL,
+    type: 'account_onboarding',
+    collect: 'eventually_due',
+  })
+}
+/**
+ * Slugifies a string.
+ * @param s
+ * @returns The slugified string.
+ */
+export function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, '')
+    .replace(/\s+/g, '-')
+    .slice(0, 100)
+}

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -37,69 +37,71 @@ export default function Login({
   }
 
   return (
-    <Flex
-      direction="column"
-      justify="center"
-      align="center"
-      width="100%"
-      height="100%"
-    >
-      <Box
-        width={{
-          initial: '100%',
-          md: '400px',
-        }}
+    <Box p={{ initial: '4', md: '8' }} height="100vh">
+      <Flex
+        direction="column"
+        justify="center"
+        align="center"
+        width="100%"
+        height="100%"
       >
-        <Card size="4">
-          <form method="post">
-            <Flex direction="column" justify="center" align="center" gap="5">
-              <Box width="100%">
-                <Heading as="h3">Sign In</Heading>
-              </Box>
-              <Box width="100%">
-                <Text as="label" align="left">
-                  Email
-                </Text>
-                <TextField.Root
-                  type="email"
-                  name="email"
-                  placeholder="Email"
-                  mt="2"
-                />
-              </Box>
+        <Box
+          width={{
+            initial: '100%',
+            md: '400px',
+          }}
+        >
+          <Card size="4">
+            <form method="post">
+              <Flex direction="column" justify="center" align="center" gap="5">
+                <Box width="100%">
+                  <Heading as="h3">Sign In</Heading>
+                </Box>
+                <Box width="100%">
+                  <Text as="label" align="left">
+                    Email
+                  </Text>
+                  <TextField.Root
+                    type="email"
+                    name="email"
+                    placeholder="Email"
+                    mt="2"
+                  />
+                </Box>
 
-              <Box width="100%">
-                <Text as="label" align="left">
-                  Password
-                </Text>
-                <TextField.Root
-                  type="password"
-                  name="password"
-                  placeholder="Password"
-                  mt="2"
-                />
-              </Box>
+                <Box width="100%">
+                  <Text as="label" align="left">
+                    Password
+                  </Text>
+                  <TextField.Root
+                    type="password"
+                    name="password"
+                    placeholder="Password"
+                    mt="2"
+                  />
+                </Box>
 
-              <Flex direction="row" width="100%" justify="end" gap="4">
-                <Link href="/service-providers/sign-up">
-                  <Button type="button" color="indigo" variant="soft">
-                    Create an account
+                <Flex direction="row" width="100%" justify="end" gap="4">
+                  <Link href="/service-providers/sign-up">
+                    <Button type="button" color="indigo" variant="soft">
+                      Create an account
+                    </Button>
+                  </Link>
+                  <Button color="indigo" variant="solid" formAction={signIn}>
+                    Sign In
                   </Button>
-                </Link>
-                <Button color="indigo" variant="solid" formAction={signIn}>
-                  Sign In
-                </Button>
-              </Flex>
+                </Flex>
 
-              {searchParams?.message && (
-                <p className="bg-foreground/10 text-foreground m-0 text-center">
-                  {searchParams.message}
-                </p>
-              )}
-            </Flex>
-          </form>
-        </Card>
-      </Box>
-    </Flex>
+                {searchParams?.message && (
+                  <p className="bg-foreground/10 text-foreground m-0 text-center">
+                    {searchParams.message}
+                  </p>
+                )}
+              </Flex>
+            </form>
+          </Card>
+        </Box>
+      </Flex>
+    </Box>
   )
 }

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -82,7 +82,7 @@ export default function Login({
                 </Box>
 
                 <Flex direction="row" width="100%" justify="end" gap="4">
-                  <Link href="/service-providers/sign-up">
+                  <Link href="/sign-up">
                     <Button type="button" color="indigo" variant="soft">
                       Create an account
                     </Button>

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -11,7 +11,7 @@ import {
   Button,
 } from '@radix-ui/themes'
 import Link from 'next/link'
-import { redirect } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { Form, useForm } from 'react-hook-form'
@@ -97,6 +97,7 @@ export default function SignUpForm() {
 }
 
 function CustomerSignupForm() {
+  const router = useRouter()
   const {
     register,
     control,
@@ -111,18 +112,21 @@ function CustomerSignupForm() {
     )
 
     setTimeout(() => {
-      redirect('/sign-in')
+      router.push('/sign-in')
     }, 5000)
   }
 
   const onError = async ({
     response,
+    error,
   }: {
     response?: Response
     error?: unknown
   }) => {
     const responseBody = await response?.json()
-    toast.error(responseBody.message)
+
+    if (responseBody) toast.error(responseBody.message)
+    if (error) toast.error(error.toString())
   }
 
   return (
@@ -217,6 +221,7 @@ function CustomerSignupForm() {
 }
 
 function ServiceProviderSignupForm() {
+  const router = useRouter()
   const {
     register,
     control,
@@ -231,18 +236,21 @@ function ServiceProviderSignupForm() {
     )
 
     setTimeout(() => {
-      redirect('/sign-in')
+      router.push('/sign-in')
     }, 5000)
   }
 
   const onError = async ({
     response,
+    error,
   }: {
     response?: Response
     error?: unknown
   }) => {
     const responseBody = await response?.json()
-    toast.error(responseBody.message)
+
+    if (responseBody) toast.error(responseBody.message)
+    if (error) toast.error(error.toString())
   }
 
   return (
@@ -331,7 +339,7 @@ function ServiceProviderSignupForm() {
           </Text>
           <TextField.Root
             required
-            placeholder="John"
+            placeholder="Jim"
             mt="2"
             mb="1"
             {...register('preferred_name')}
@@ -348,7 +356,7 @@ function ServiceProviderSignupForm() {
           <TextField.Root
             required
             type="text"
-            placeholder="John Smith"
+            placeholder="Jim Smith"
             mt="2"
             mb="1"
             {...register('fullname')}
@@ -365,7 +373,7 @@ function ServiceProviderSignupForm() {
           <TextField.Root
             required
             type="email"
-            placeholder="john.smith@email.com"
+            placeholder="jim.smith@email.com"
             mt="2"
             mb="1"
             {...register('email')}

--- a/src/types/forms.ts
+++ b/src/types/forms.ts
@@ -15,9 +15,19 @@ export const serviceProviderSignupFormSchema = zfd.formData({
   password: zfd.text(z.string().min(8)),
   preferred_name: zfd.text(z.string()),
   fullname: zfd.text(z.string()),
-  company_name: zfd.text(z.string()),
-  abn: zfd.text(z.string().length(11)),
-  acn: zfd.text(z.string().length(9).optional()),
+  company_name: zfd.text(z.string().trim()), // Add .trim() to remove leading and trailing whitespace
+  abn: zfd.text(
+    z
+      .string()
+      .transform(s => s.replace(/\s/g, ''))
+      .pipe(z.string().length(11).regex(/^\d+$/)),
+  ),
+  acn: zfd.text(
+    z
+      .string()
+      .transform(s => s.replace(/\s/g, ''))
+      .pipe(z.string().length(9).regex(/^\d+$/).optional()),
+  ),
   industry: zfd.text(z.string()),
 })
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -11,16 +11,19 @@ export type Database = {
     Tables: {
       customers: {
         Row: {
+          fullname: string
           preferred_name: string
           profile_picture: string | null
           user_id: string
         }
         Insert: {
+          fullname: string
           preferred_name: string
           profile_picture?: string | null
           user_id: string
         }
         Update: {
+          fullname?: string
           preferred_name?: string
           profile_picture?: string | null
           user_id?: string
@@ -39,28 +42,37 @@ export type Database = {
         Row: {
           abn: string
           acn: string | null
+          company_name: string
           cover_image_url: string | null
-          name: string
+          fullname: string
+          industry: string
+          preferred_name: string
           profile_image_url: string | null
-          slug: string | null
+          slug: string
           user_id: string
         }
         Insert: {
           abn: string
           acn?: string | null
+          company_name: string
           cover_image_url?: string | null
-          name: string
+          fullname: string
+          industry: string
+          preferred_name: string
           profile_image_url?: string | null
-          slug?: string | null
+          slug: string
           user_id: string
         }
         Update: {
           abn?: string
           acn?: string | null
+          company_name?: string
           cover_image_url?: string | null
-          name?: string
+          fullname?: string
+          industry?: string
+          preferred_name?: string
           profile_image_url?: string | null
-          slug?: string | null
+          slug?: string
           user_id?: string
         }
         Relationships: [

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -83,13 +83,6 @@ export type Database = {
             referencedRelation: 'users'
             referencedColumns: ['id']
           },
-          {
-            foreignKeyName: 'service_providers_user_id_fkey1'
-            columns: ['user_id']
-            isOneToOne: true
-            referencedRelation: 'users'
-            referencedColumns: ['id']
-          },
         ]
       }
       users: {

--- a/supabase/migrations/20240312113046_table_add_service_providers.sql
+++ b/supabase/migrations/20240312113046_table_add_service_providers.sql
@@ -1,12 +1,16 @@
 -- SERVICE PROVIDERS
 create table public.service_providers (
   user_id           uuid references users not null primary key,
-  name              text not null,
-  slug              text,
-  profile_image_url text,
-  cover_image_url   text,
+  company_name      text not null,
   abn               text not null,
   acn               text,
+  industry          text not null,
+  preferred_name    text not null,
+  fullname          text not null,
+
+  profile_image_url text,
+  cover_image_url   text,
+  slug              text not null unique,
 
   foreign key (user_id) references auth.users(id)
 );

--- a/supabase/migrations/20240312113046_table_add_service_providers.sql
+++ b/supabase/migrations/20240312113046_table_add_service_providers.sql
@@ -1,6 +1,6 @@
 -- SERVICE PROVIDERS
 create table public.service_providers (
-  user_id           uuid references users not null primary key,
+  user_id           uuid not null primary key,
   company_name      text not null,
   abn               text not null,
   acn               text,


### PR DESCRIPTION
### Note: Service Provider Users are not prompted with Stripe Connect Onboarding URL in this PR
Onboarding finalization will still need to be implemented.

### Changes
**Backend**
- implement new service providers sign-up endpoint
  - this creates an account with Stripe Connect and stores the accountId and the onboarding url in the user metadata.

**Frontend**
- add input validation for ServiceProvider Signup form
- display input validation errors
- display toast upon form submissions (success + failure)
- redirect user after 5 seconds upon successful form submissions.

### Resources
docs: 
- https://docs.stripe.com/connect

previous implementation:
- https://github.com/codesydney/migram-frontend/blob/main/src/pages/api/service-providers/index.ts
- https://github.com/codesydney/migram-frontend/blob/c7c843cc808cc678c46f47a3f794f20758d16cb6/src/backend/services/payments/connect.ts

### Related
- #25
- #26
- #28
- #4