### PR TITLE
migrations: add onboarding_status field to service_providers table

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -53,6 +53,7 @@ export type Database = {
           created_at: string | null
           fullname: string
           industry: string
+          onboarding_status: boolean
           preferred_name: string
           profile_image_url: string | null
           slug: string
@@ -67,6 +68,7 @@ export type Database = {
           created_at?: string | null
           fullname: string
           industry: string
+          onboarding_status?: boolean
           preferred_name: string
           profile_image_url?: string | null
           slug: string
@@ -81,6 +83,7 @@ export type Database = {
           created_at?: string | null
           fullname?: string
           industry?: string
+          onboarding_status?: boolean
           preferred_name?: string
           profile_image_url?: string | null
           slug?: string

--- a/supabase/migrations/20240605073517_service_providers_add_onboarding_status.sql
+++ b/supabase/migrations/20240605073517_service_providers_add_onboarding_status.sql
@@ -1,0 +1,11 @@
+/*
+  Adds an indexed onboarding_status field to the service_providers table.
+
+  This index is necessary to support the access pattern of displaying onboarded service provider profiles on the List
+  of Service Providers Page.
+*/
+
+alter table service_providers
+add column onboarding_status boolean default false not null;
+
+create index onboarded_service_providers_idx on service_providers (onboarding_status);


### PR DESCRIPTION
This field is indexed because we need to support the access pattern of displaying onboarded service provider profiles on the Service Providers List Page.